### PR TITLE
feat: add navbar with theme toggle

### DIFF
--- a/web-tutelkan/src/components/Navbar.astro
+++ b/web-tutelkan/src/components/Navbar.astro
@@ -1,0 +1,25 @@
+---
+import ThemeToggle from './ThemeToggle.astro';
+const links = [
+  { href: '/', label: 'Inicio' },
+  { href: '/servicios', label: 'Servicios' },
+  { href: '/contacto', label: 'Contacto' }
+];
+---
+<nav class="border-b border-gray-200 dark:border-gray-700">
+  <div class="max-w-screen-xl mx-auto p-4 flex items-center justify-between">
+    <a href="/" class="flex items-center space-x-2">
+      <img src="/favicon.svg" alt="Tutelkan logo" class="h-8 w-8" />
+      <span class="text-xl font-semibold dark:text-white">Tutelkan</span>
+    </a>
+    <ul class="hidden md:flex space-x-8 font-medium">
+      {links.map(link => (
+        <li><a href={link.href} class="text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400">{link.label}</a></li>
+      ))}
+    </ul>
+    <div class="flex items-center space-x-4">
+      <a href="#contacto" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Conversemos</a>
+      <ThemeToggle />
+    </div>
+  </div>
+</nav>

--- a/web-tutelkan/src/components/ThemeToggle.astro
+++ b/web-tutelkan/src/components/ThemeToggle.astro
@@ -1,0 +1,27 @@
+---
+---
+<button id="theme-toggle" class="p-2 rounded border border-gray-300 dark:border-gray-600">
+  <span class="sr-only">Toggle dark mode</span>
+  <svg id="theme-toggle-light" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 01-2 0V3a1 1 0 011-1zm4.22.97a1 1 0 011.42 0l.7.7a1 1 0 01-1.41 1.42l-.71-.7a1 1 0 010-1.42zM18 9a1 1 0 100 2h1a1 1 0 100-2h-1zM14.22 15.03a1 1 0 010 1.42l-.7.7a1 1 0 11-1.42-1.42l.7-.7a1 1 0 011.42 0zM10 16a1 1 0 011 1v1a1 1 0 01-2 0v-1a1 1 0 011-1zM5.78 15.03a1 1 0 00-1.42 0l-.7.7a1 1 0 001.41 1.42l.71-.7a1 1 0 000-1.42zM4 9a1 1 0 000 2H3a1 1 0 100-2h1zM5.78 4.97a1 1 0 00-1.42 0l-.7.7a1 1 0 001.41 1.42l.71-.7a1 1 0 000-1.42z"/>
+  </svg>
+  <svg id="theme-toggle-dark" class="w-5 h-5 hidden" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8 8 0 1010.586 10.586z"/></svg>
+</button>
+<script>
+const toggle = document.getElementById('theme-toggle');
+const darkIcon = document.getElementById('theme-toggle-dark');
+const lightIcon = document.getElementById('theme-toggle-light');
+
+if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+  document.documentElement.classList.add('dark');
+  darkIcon.classList.remove('hidden');
+} else {
+  lightIcon.classList.remove('hidden');
+}
+
+toggle.addEventListener('click', () => {
+  darkIcon.classList.toggle('hidden');
+  lightIcon.classList.toggle('hidden');
+  document.documentElement.classList.toggle('dark');
+  localStorage.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+});
+</script>

--- a/web-tutelkan/src/layouts/Layout.astro
+++ b/web-tutelkan/src/layouts/Layout.astro
@@ -1,3 +1,20 @@
 ---
-import '../styles/global.css'
----  
+import '../styles/global.css';
+import Navbar from '../components/Navbar.astro';
+const { title = 'Tutelkan' } = Astro.props;
+---
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+    <slot name="head" />
+  </head>
+  <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <Navbar />
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/web-tutelkan/src/pages/index.astro
+++ b/web-tutelkan/src/pages/index.astro
@@ -1,16 +1,6 @@
 ---
-
+import Layout from '../layouts/Layout.astro';
 ---
-
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<Layout title="Inicio">
+  <h1 class="text-4xl font-bold">Astro</h1>
+</Layout>

--- a/web-tutelkan/tailwind.config.mjs
+++ b/web-tutelkan/tailwind.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config for class-based dark mode
- introduce Navbar with logo, links, Conversemos button and theme toggle
- wrap pages with Layout including new navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68916b27aeb4832c8b37d7bf3b1b0ba1