### PR TITLE
feat: add light theme landing page

### DIFF
--- a/web-tutelkan/src/components/Footer.astro
+++ b/web-tutelkan/src/components/Footer.astro
@@ -1,0 +1,26 @@
+---
+const year = new Date().getFullYear();
+---
+<footer class="bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-gray-300">
+  <div class="max-w-screen-xl mx-auto px-4 py-8 flex flex-col md:flex-row items-center justify-between">
+    <div class="flex items-center space-x-2">
+      <img src="/favicon.svg" alt="Tutelkan logo" class="h-10 w-10" />
+    </div>
+    <div class="flex space-x-4 mt-4 md:mt-0">
+      <a href="#" class="hover:text-[#cf3339]" aria-label="Facebook"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M22 12a10 10 0 10-11.5 9.9v-7h-2v-2.9h2V9.5c0-2 1.2-3.1 3-3.1.9 0 1.8.1 1.8.1v2h-1c-1 0-1.3.6-1.3 1.2v1.4h2.6l-.4 2.9h-2.2v7A10 10 0 0022 12z"/></svg></a>
+      <a href="#" class="hover:text-[#cf3339]" aria-label="Instagram"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M7 2C4.2 2 2 4.2 2 7v10c0 2.8 2.2 5 5 5h10c2.8 0 5-2.2 5-5V7c0-2.8-2.2-5-5-5H7zm10 2c1.7 0 3 1.3 3 3v10c0 1.7-1.3 3-3 3H7c-1.7 0-3-1.3-3-3V7c0-1.7 1.3-3 3-3h10zm-5 3a5 5 0 100 10 5 5 0 000-10zm0 2a3 3 0 110 6 3 3 0 010-6zm4.5-.9a1.1 1.1 0 100 2.2 1.1 1.1 0 000-2.2z"/></svg></a>
+      <a href="#" class="hover:text-[#cf3339]" aria-label="LinkedIn"><svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24"><path d="M4.98 3.5a2.5 2.5 0 11-.02 5.001 2.5 2.5 0 01.02-5.001zM3 8.98h4v12H3v-12zm7 0h3.8v1.6h.1c.5-.9 1.7-1.8 3.6-1.8 3.9 0 4.6 2.6 4.6 5.9v6.3h-4v-5.6c0-1.3 0-3-1.9-3s-2.2 1.5-2.2 2.9v5.7h-4v-12z"/></svg></a>
+    </div>
+  </div>
+  <div class="border-t border-gray-300 dark:border-gray-700 py-4">
+    <div class="max-w-screen-xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center text-sm space-y-2 md:space-y-0">
+      <div class="flex flex-wrap justify-center md:justify-start gap-4">
+        <a href="#" class="hover:text-[#cf3339]">Condiciones de uso</a>
+        <a href="#" class="hover:text-[#cf3339]">Política de privacidad</a>
+        <a href="#" class="hover:text-[#cf3339]">Código de ética</a>
+        <a href="#" class="hover:text-[#cf3339]">Canal de denuncias</a>
+      </div>
+      <span class="text-center md:text-right">© {year} Tutelkan</span>
+    </div>
+  </div>
+</footer>

--- a/web-tutelkan/src/components/Navbar.astro
+++ b/web-tutelkan/src/components/Navbar.astro
@@ -1,9 +1,11 @@
 ---
 import ThemeToggle from './ThemeToggle.astro';
 const links = [
-  { href: '/', label: 'Inicio' },
-  { href: '/servicios', label: 'Servicios' },
-  { href: '/contacto', label: 'Contacto' }
+  { href: '#home', label: 'Home' },
+  { href: '#nosotros', label: 'Nosotros' },
+  { href: '#servicios', label: 'Servicios' },
+  { href: '#portafolio', label: 'Portafolio' },
+  { href: '/blog', label: 'Blog' }
 ];
 ---
 <nav class="border-b border-gray-200 dark:border-gray-700">
@@ -18,7 +20,7 @@ const links = [
       ))}
     </ul>
     <div class="flex items-center space-x-4">
-      <a href="#contacto" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Conversemos</a>
+      <a href="#contacto" class="bg-[#cf3339] text-white px-4 py-2 rounded hover:bg-[#b52d32]">Conversemos</a>
       <ThemeToggle />
     </div>
   </div>

--- a/web-tutelkan/src/components/ThemeToggle.astro
+++ b/web-tutelkan/src/components/ThemeToggle.astro
@@ -1,9 +1,8 @@
 ---
 ---
-<button id="theme-toggle" class="p-2 rounded border border-gray-300 dark:border-gray-600">
-  <span class="sr-only">Toggle dark mode</span>
-  <svg id="theme-toggle-light" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 01-2 0V3a1 1 0 011-1zm4.22.97a1 1 0 011.42 0l.7.7a1 1 0 01-1.41 1.42l-.71-.7a1 1 0 010-1.42zM18 9a1 1 0 100 2h1a1 1 0 100-2h-1zM14.22 15.03a1 1 0 010 1.42l-.7.7a1 1 0 11-1.42-1.42l.7-.7a1 1 0 011.42 0zM10 16a1 1 0 011 1v1a1 1 0 01-2 0v-1a1 1 0 011-1zM5.78 15.03a1 1 0 00-1.42 0l-.7.7a1 1 0 001.41 1.42l.71-.7a1 1 0 000-1.42zM4 9a1 1 0 000 2H3a1 1 0 100-2h1zM5.78 4.97a1 1 0 00-1.42 0l-.7.7a1 1 0 001.41 1.42l.71-.7a1 1 0 000-1.42z"/>
-  </svg>
+<button id="theme-toggle" class="p-2 rounded-full border border-gray-300 bg-white text-[#cf3339] hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-600 dark:text-[#cf3339]">
+  <span class="sr-only">Cambiar tema</span>
+  <svg id="theme-toggle-light" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 01-2 0V3a1 1 0 011-1zm4.22.97a1 1 0 011.42 0l.7.7a1 1 0 01-1.41 1.42l-.71-.7a1 1 0 010-1.42zM18 9a1 1 0 100 2h1a1 1 0 100-2h-1zM14.22 15.03a1 1 0 010 1.42l-.7.7a1 1 0 11-1.42-1.42l.7-.7a1 1 0 011.42 0zM10 16a1 1 0 011 1v1a1 1 0 01-2 0v-1a1 1 0 011-1zM5.78 15.03a1 1 0 00-1.42 0l-.7.7a1 1 0 001.41 1.42l.71-.7a1 1 0 000-1.42zM4 9a1 1 0 000 2H3a1 1 0 100-2h1zM5.78 4.97a1 1 0 00-1.42 0l-.7.7a1 1 0 001.41 1.42l.71-.7a1 1 0 000-1.42z"/></svg>
   <svg id="theme-toggle-dark" class="w-5 h-5 hidden" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8 8 0 1010.586 10.586z"/></svg>
 </button>
 <script>

--- a/web-tutelkan/src/layouts/Layout.astro
+++ b/web-tutelkan/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import Navbar from '../components/Navbar.astro';
+import Footer from '../components/Footer.astro';
 const { title = 'Tutelkan' } = Astro.props;
 ---
 <html lang="es">
@@ -11,10 +12,23 @@ const { title = 'Tutelkan' } = Astro.props;
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <Navbar />
     <main>
       <slot />
     </main>
+    <Footer />
+    <script>
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('show');
+          }
+        });
+      }, { threshold: 0.1 });
+      document.querySelectorAll('.fade-section').forEach((section) => {
+        observer.observe(section);
+      });
+    </script>
   </body>
 </html>

--- a/web-tutelkan/src/pages/blog.astro
+++ b/web-tutelkan/src/pages/blog.astro
@@ -1,0 +1,9 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Blog">
+  <section class="max-w-screen-xl mx-auto px-4 py-20">
+    <h1 class="text-4xl font-bold text-center text-[#cf3339]">Blog</h1>
+    <p class="mt-4 text-center">Próximamente.</p>
+  </section>
+</Layout>

--- a/web-tutelkan/src/pages/index.astro
+++ b/web-tutelkan/src/pages/index.astro
@@ -1,6 +1,253 @@
 ---
 import Layout from '../layouts/Layout.astro';
+
+const services = [
+  {
+    title: 'Desarrollo de Software a Medida',
+    description: 'La personalización es la esencia de la innovación. En Tutelkan, diseñamos soluciones de software únicas, pensadas para impulsar la innovación y eficiencia en tu empresa, delineando el camino hacia un futuro tecnológicamente avanzado.'
+  },
+  {
+    title: 'Soluciones de Automatización Industrial',
+    description: 'Implementamos soluciones de automatización que no solo optimizan tus operaciones industriales, sino que también mejoran la seguridad y la eficiencia, preparando tu empresa para el futuro de la Industria 4.0.'
+  },
+  {
+    title: 'Aplicaciones Móviles y Web en Tiempo Real',
+    description: 'Desarrollamos aplicaciones móviles y web que proporcionan monitoreo y control en tiempo real, permitiendo una respuesta rápida y decisiones basadas en datos.'
+  },
+  {
+    title: 'Integraciones de Sistemas Empresariales y de Planta',
+    description: 'Facilitamos la cohesión en tu empresa, integrando eficientemente sistemas ERP, legados e interfaces de piso de planta, uniendo todas las áreas de tu negocio para una operatividad sinérgica y optimizada.'
+  },
+  {
+    title: 'Consultoría en Innovación Tecnológica',
+    description: 'Brindamos consultoría experta para ayudarte a identificar y aplicar las soluciones tecnológicas más innovadoras en tu sector, asegurando que tu empresa esté siempre a la vanguardia.'
+  },
+  {
+    title: 'Mantenimiento y Soporte Técnico',
+    description: 'Ofrecemos servicios de mantenimiento y soporte técnico de alta calidad, garantizando que tus sistemas estén siempre funcionando a su máxima capacidad, y ayudándote a resolver cualquier problema que pueda surgir de manera eficiente.'
+  }
+];
+
+const projects = [
+  { title: 'Proyecto Uno', image: 'https://via.placeholder.com/400x300', link: '#' },
+  { title: 'Proyecto Dos', image: 'https://via.placeholder.com/400x300', link: '#' },
+  { title: 'Proyecto Tres', image: 'https://via.placeholder.com/400x300', link: '#' }
+];
+
+const testimonials = [
+  { quote: 'Excelente servicio y atención.', author: 'María López', role: 'Cliente' },
+  { quote: 'Profesionales y comprometidos.', author: 'José Pérez', role: 'Cliente' },
+  { quote: 'Soluciones innovadoras.', author: 'Ana García', role: 'Cliente' }
+];
+
+const faqs = [
+  { question: '¿Cómo puedo solicitar un proyecto?', answer: 'Contáctanos a través del formulario y conversaremos.' },
+  { question: '¿Ofrecen soporte 24/7?', answer: 'Sí, contamos con personal disponible todo el día.' },
+  { question: '¿Trabajan con empresas pequeñas?', answer: 'Sí, adaptamos nuestras soluciones a cualquier tamaño de empresa.' }
+];
 ---
 <Layout title="Inicio">
-  <h1 class="text-4xl font-bold">Astro</h1>
+  <!-- Hero -->
+  <section id="home" class="fade-section max-w-screen-xl mx-auto px-4 py-20 flex flex-col md:flex-row items-center gap-8">
+    <div class="flex-1">
+      <h1 class="text-4xl md:text-5xl font-bold text-[#cf3339]">Creamos software a medida, que optimizan tu negocio</h1>
+      <p class="mt-4 text-lg">En Tutelkan, solucionamos problemas y mejoramos los procesos de tu empresa sin importar su tamaño.</p>
+      <div class="mt-6">
+        <a href="#contacto" class="bg-[#cf3339] text-white px-6 py-3 rounded hover:bg-[#b52d32]">Conversemos</a>
+      </div>
+    </div>
+    <div class="flex-1">
+      <img src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=800&q=80" alt="Computador" class="w-full rounded shadow" />
+    </div>
+  </section>
+
+  <!-- Servicios -->
+  <section id="servicios" class="fade-section bg-white py-20">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-[#cf3339]">Nuestros servicios</h2>
+      <p class="mt-4 text-center font-semibold">¿Qué ofrecemos?</p>
+      <p class="mt-2 text-center">En Tutelkan, damos vida a soluciones tecnológicas únicas, diseñadas meticulosamente para satisfacer tus necesidades industriales específicas. Sumérgete en un mundo de servicios que fusionan innovación y eficiencia, siendo la clave para propulsar tu empresa hacia el éxito en la era de la Industria 4.0.</p>
+      <div class="mt-10 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        {services.map((service, index) => (
+          <div class="p-6 border border-gray-200 rounded shadow-sm bg-gray-50">
+            <span class="text-[#cf3339] font-bold">{index + 1}.- {service.title}</span>
+            <p class="mt-2 text-sm">{service.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Sobre nosotros -->
+  <section id="nosotros" class="fade-section bg-gray-100 py-20">
+    <div class="max-w-screen-xl mx-auto px-4 flex flex-col md:flex-row items-center gap-8">
+      <div class="flex-1">
+        <h2 class="text-3xl font-bold text-[#cf3339]">Impulsando la innovación tecnológica desde el 2006</h2>
+        <p class="mt-4 text-lg">Tutelkan surgió para suplir una carencia en la industria manufacturera, ofreciendo soluciones de software y soporte técnico de primera línea. Desde entonces, hemos expandido nuestro campo de acción a sectores como el forestal, alimentario, agrícola y más, con una rica trayectoria de proyectos exitosos. Nos distinguimos por nuestra expertise en soluciones tecnológicas personalizadas, enfocándonos constantemente en potenciar la eficiencia y competitividad de nuestros clientes.</p>
+      </div>
+      <div class="flex-1">
+        <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80" alt="Equipo" class="w-full rounded shadow" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Soporte -->
+  <section id="soporte" class="fade-section py-20">
+    <div class="max-w-screen-xl mx-auto px-4 flex flex-col md:flex-row items-center gap-8">
+      <div class="flex-1 order-2 md:order-1">
+        <img src="https://images.unsplash.com/photo-1581093458791-9d4c6ee8e0f3?auto=format&fit=crop&w=800&q=80" alt="Soporte" class="w-full rounded shadow" />
+      </div>
+      <div class="flex-1 order-1 md:order-2">
+        <span class="text-[#cf3339] font-semibold">SOPORTE Y MANTENCIÓN</span>
+        <h2 class="text-3xl font-bold mt-2 text-[#cf3339]">Asistencia técnica ininterrumpida: Tu confianza, nuestra prioridad</h2>
+        <p class="mt-4">Nuestro compromiso es garantizar que tus operaciones nunca se detengan, ofreciendo un soporte técnico y servicios de mantenimiento que están a la altura de tus expectativas.</p>
+        <div class="mt-6 grid grid-cols-2 gap-4">
+          {['Respuesta Rápida','Soporte 24/7','Personal Calificado','Mantenimiento Proactivo'].map(item => (
+            <button class="border border-[#cf3339] text-[#cf3339] px-4 py-2 rounded" aria-label={item}>{item}</button>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Estadísticas -->
+  <section class="fade-section bg-[#cf3339] text-white py-20">
+    <div class="max-w-screen-xl mx-auto px-4 grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+      <div>
+        <p class="text-4xl font-bold">+18</p>
+        <p class="mt-2">Años de experiencia</p>
+      </div>
+      <div>
+        <p class="text-4xl font-bold">+200</p>
+        <p class="mt-2">Proyectos finalizados</p>
+      </div>
+      <div>
+        <p class="text-4xl font-bold">+20000</p>
+        <p class="mt-2">Horas de soporte</p>
+      </div>
+      <div>
+        <p class="text-4xl font-bold">+50</p>
+        <p class="mt-2">Tecnologías utilizadas</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Por qué elegirnos -->
+  <section id="porque" class="fade-section py-20 bg-white">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-[#cf3339]">Por qué nuestros clientes nos eligen</h2>
+      <p class="mt-4 text-center">Nos posicionamos como tu socio confiable, guiando tu negocio hacia un horizonte de innovación y eficiencia.</p>
+      <div class="mt-10 grid gap-8 md:grid-cols-3">
+        <div class="p-6 border border-gray-200 rounded text-center">
+          <span class="text-[#cf3339] font-bold text-2xl">01.</span>
+          <h3 class="mt-4 font-semibold">Soluciones Garantizadas</h3>
+          <p class="mt-2 text-sm">Cada proyecto que emprendemos está respaldado por nuestra garantía de satisfacción, asegurando que cumplimos con tus expectativas en cada etapa.</p>
+        </div>
+        <div class="p-6 border border-gray-200 rounded text-center">
+          <span class="text-[#cf3339] font-bold text-2xl">02.</span>
+          <h3 class="mt-4 font-semibold">Colaboración Cercana</h3>
+          <p class="mt-2 text-sm">Valoramos la colaboración y la comunicación abierta con nuestros clientes. Este enfoque colaborativo nos permite trabajar juntos para desarrollar soluciones que reflejen tus visiones y metas a la perfección.</p>
+        </div>
+        <div class="p-6 border border-gray-200 rounded text-center">
+          <span class="text-[#cf3339] font-bold text-2xl">03.</span>
+          <h3 class="mt-4 font-semibold">Experiencia y Vanguardia</h3>
+          <p class="mt-2 text-sm">Con 18 años de experiencia a nuestras espaldas, combinamos nuestra profunda comprensión del sector con un enfoque innovador, asegurando que cada solución que desarrollamos está a la vanguardia, marcando tendencias en el sector industrial.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Portafolio -->
+  <section id="portafolio" class="fade-section bg-gray-100 py-20">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-[#cf3339]">Nuestro Portafolio</h2>
+      <p class="mt-4 text-center">Descubre algunas de las soluciones innovadoras que hemos implementado, reflejo de nuestro compromiso con la excelencia y la adaptación a las necesidades específicas de cada industria. Estas soluciones son sólo una muestra de la amplia gama de soluciones que ofrecemos.</p>
+      <div class="mt-10 grid gap-8 md:grid-cols-3">
+        {projects.map(project => (
+          <a href={project.link} class="block border border-gray-200 rounded overflow-hidden hover:shadow-lg">
+            <img src={project.image} alt={project.title} class="w-full h-48 object-cover" />
+            <div class="p-4">
+              <h3 class="font-semibold">{project.title}</h3>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Logos -->
+  <section id="clientes" class="fade-section py-20">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-[#cf3339]">Han confiado en nosotros</h2>
+      <div class="mt-10 overflow-x-auto">
+        <div class="flex items-center gap-10">
+          {Array.from({ length: 6 }).map(() => (
+            <img src="https://via.placeholder.com/150x80?text=Logo" alt="Logo" class="h-20 w-auto flex-shrink-0" />
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Testimonios -->
+  <section id="testimonios" class="fade-section bg-gray-100 py-20">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-[#cf3339]">Testimonios</h2>
+      <div class="mt-10 flex overflow-x-auto gap-8 snap-x">
+        {testimonials.map(test => (
+          <div class="min-w-[300px] snap-center p-6 bg-white border border-gray-200 rounded shadow">
+            <p>"{test.quote}"</p>
+            <p class="mt-4 font-semibold">{test.author}</p>
+            <p class="text-sm">{test.role}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section id="faq" class="fade-section py-20">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <h2 class="text-3xl font-bold text-center text-[#cf3339]">Preguntas frecuentes</h2>
+      <div class="mt-10 space-y-4">
+        {faqs.map(faq => (
+          <details class="border border-gray-200 rounded">
+            <summary class="cursor-pointer px-4 py-2 font-medium">{faq.question}</summary>
+            <p class="px-4 py-2 bg-gray-50">{faq.answer}</p>
+          </details>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Contacto -->
+  <section id="contacto" class="fade-section bg-gray-100 py-20">
+    <div class="max-w-screen-xl mx-auto px-4 grid md:grid-cols-2 gap-8">
+      <div>
+        <h2 class="text-3xl font-bold text-[#cf3339]">Contáctanos</h2>
+        <p class="mt-4">Teléfono: +56 9 1234 5678</p>
+        <p class="mt-2">Email: contacto@tutelkan.com</p>
+        <p class="mt-2">Dirección: Calle Falsa 123, Santiago</p>
+      </div>
+      <form class="space-y-4">
+        <div class="grid grid-cols-2 gap-4">
+          <input type="text" placeholder="Nombre" class="border border-gray-300 p-2 rounded" />
+          <input type="text" placeholder="Apellidos" class="border border-gray-300 p-2 rounded" />
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+          <input type="email" placeholder="Email" class="border border-gray-300 p-2 rounded" />
+          <input type="tel" placeholder="Teléfono" class="border border-gray-300 p-2 rounded" />
+        </div>
+        <textarea placeholder="Mensaje" class="w-full border border-gray-300 p-2 rounded" rows="4"></textarea>
+        <button type="button" class="bg-[#cf3339] text-white px-6 py-2 rounded hover:bg-[#b52d32]">Enviar</button>
+      </form>
+    </div>
+  </section>
+
+  <!-- Mapa -->
+  <section id="mapa" class="fade-section py-20">
+    <div class="max-w-screen-xl mx-auto px-4">
+      <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3329.093297073735!2d-70.64826958421102!3d-33.44888998078145!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x9662c59e1f97d0b1%3A0x414a707d4b1f9a7!2sSantiago%2C%20Chile!5e0!3m2!1ses-419!2scl!4v1616626930141!5m2!1ses-419!2scl" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+    </div>
+  </section>
 </Layout>

--- a/web-tutelkan/src/styles/global.css
+++ b/web-tutelkan/src/styles/global.css
@@ -1,1 +1,13 @@
 @import "tailwindcss";
+
+/* Animations for section reveal */
+.fade-section {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+
+.fade-section.show {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- design navbar with anchors and blog link
- improve theme toggle and add animated light-themed landing sections
- create footer with social links and company policies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68917236d924832cb3c79e5c44ed8470