### PR TITLE
Organize section animations into separate scripts

### DIFF
--- a/web-tutelkan/src/components/sections/About.astro
+++ b/web-tutelkan/src/components/sections/About.astro
@@ -9,3 +9,4 @@
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/about.js"></script>

--- a/web-tutelkan/src/components/sections/Clients.astro
+++ b/web-tutelkan/src/components/sections/Clients.astro
@@ -1,4 +1,4 @@
-<section id="clients" class="py-16 bg-gray-100">
+<section id="clients" class="py-16 bg-gray-100 section-animate">
   <div class="max-w-screen-xl mx-auto px-4">
     <!-- Título alineado a la izquierda y más pequeño -->
     <h2 class="text-lg md:text-xl font-bold text-left text-red-600 mb-8 animate-slide-up">
@@ -44,79 +44,4 @@
   .animate-delay-5 { animation-delay: 0.5s; }
   .animate-delay-6 { animation-delay: 0.6s; }
 </style>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    // Array completo de logos
-    const logos = [
-      { src: '/images/clients-logos/1-CMPC.webp', alt: 'CMPC' },
-      { src: '/images/clients-logos/2-Arauco.webp', alt: 'Arauco' },
-      { src: '/images/clients-logos/3-PF-Alimentos.webp', alt: 'PF Alimentos' },
-      { src: '/images/clients-logos/3-white.webp', alt: 'White' },
-      { src: '/images/clients-logos/4-Unifrutti.webp', alt: 'Unifrutti' },
-      { src: '/images/clients-logos/5-LFE.webp', alt: 'LFE' },
-      { src: '/images/clients-logos/6-UTalca.webp', alt: 'Utalca' },
-      { src: '/images/clients-logos/7-Socoepa.webp', alt: 'Socoepa' },
-      { src: '/images/clients-logos/8-Oriencoop.webp', alt: 'Oriencoop' },
-      { src: '/images/clients-logos/9-Puertos-de-Talcahuano.webp', alt: 'Puertos de Talcahuano' },
-      { src: '/images/clients-logos/10-Danich.webp', alt: 'Danich' },
-      { src: '/images/clients-logos/11-Nebiolo.webp', alt: 'Nebiolo' },
-      { src: '/images/clients-logos/12-Servimak.webp', alt: 'Servimak' },
-      { src: '/images/clients-logos/13-Forestal-Río-Claro.webp', alt: 'Friosur Klaro' },
-      { src: '/images/clients-logos/14-Promaule.webp', alt: 'Promaule' },
-      { src: '/images/clients-logos/15-double-ju.webp', alt: 'Double Ju' },
-      { src: '/images/clients-logos/16-subus.webp', alt: 'Subus' },
-      { src: '/images/clients-logos/17-flowersindesign.webp', alt: 'Flowers in Design' },
-      { src: '/images/clients-logos/18-pasche.webp', alt: 'Pasche' },
-      { src: '/images/clients-logos/19-logo-gottingen.webp', alt: 'Gottingen' }
-    ];
-
-    const track = document.getElementById('carousel-track');
-    let currentIndex = 0;
-    const visibleLogos = 6;
-
-    function updateCarousel() {
-      // Limpiar el track
-      track.innerHTML = '';
-      
-      // Crear los 6 logos visibles con clases de Tailwind
-      for (let i = 0; i < visibleLogos; i++) {
-        const logoIndex = (currentIndex + i) % logos.length;
-        const logoData = logos[logoIndex];
-        
-        // Crear imagen con clases de Tailwind CSS - Cards más grandes
-        const img = document.createElement('img');
-        img.src = logoData.src;
-        img.alt = logoData.alt;
-        img.className = `h-24 md:h-28 w-auto flex-shrink-0 opacity-70 hover:opacity-100 hover:scale-105 transition-all duration-300 cursor-pointer animate-fade-scale animate-delay-${i + 1}`;
-        
-        track.appendChild(img);
-      }
-
-      // Avanzar al siguiente conjunto
-      currentIndex = (currentIndex + 1) % logos.length;
-    }
-
-    // Inicializar el carrusel
-    updateCarousel();
-
-    // Cambiar cada 3 segundos
-    setInterval(updateCarousel, 3000);
-
-    // Activar animación del título cuando sea visible
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          const title = entry.target.querySelector('.animate-slide-up');
-          if (title) {
-            title.style.animationPlayState = 'running';
-          }
-        }
-      });
-    }, {
-      threshold: 0.1
-    });
-
-    observer.observe(document.getElementById('clients'));
-  });
-</script>
+<script type="module" src="/src/scripts/sections/clients.js"></script>

--- a/web-tutelkan/src/components/sections/Contact.astro
+++ b/web-tutelkan/src/components/sections/Contact.astro
@@ -69,3 +69,4 @@
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/contact.js"></script>

--- a/web-tutelkan/src/components/sections/Faq.astro
+++ b/web-tutelkan/src/components/sections/Faq.astro
@@ -18,3 +18,4 @@ const faqs = [
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/faq.js"></script>

--- a/web-tutelkan/src/components/sections/Hero.astro
+++ b/web-tutelkan/src/components/sections/Hero.astro
@@ -21,3 +21,4 @@
   </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/hero.js"></script>

--- a/web-tutelkan/src/components/sections/Map.astro
+++ b/web-tutelkan/src/components/sections/Map.astro
@@ -3,3 +3,4 @@
     <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3329.093297073735!2d-70.64826958421102!3d-33.44888998078145!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x9662c59e1f97d0b1%3A0x414a707d4b1f9a7!2sSantiago%2C%20Chile!5e0!3m2!1ses-419!2scl!4v1616626930141!5m2!1ses-419!2scl" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" class="rounded-lg shadow-lg animate-slide-up"></iframe>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/map.js"></script>

--- a/web-tutelkan/src/components/sections/Portfolio.astro
+++ b/web-tutelkan/src/components/sections/Portfolio.astro
@@ -21,3 +21,4 @@ const projects = [
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/portfolio.js"></script>

--- a/web-tutelkan/src/components/sections/Services.astro
+++ b/web-tutelkan/src/components/sections/Services.astro
@@ -60,3 +60,4 @@ const services = [
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/services.js"></script>

--- a/web-tutelkan/src/components/sections/Stats.astro
+++ b/web-tutelkan/src/components/sections/Stats.astro
@@ -1,4 +1,4 @@
-<section class="bg-[#cf3339] text-white py-20 section-animate">
+<section id="stats" class="bg-[#cf3339] text-white py-20 section-animate">
   <div class="max-w-screen-xl mx-auto px-4 grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
     <div class="animate-slide-up animate-delay-1">
       <p class="text-4xl md:text-5xl font-bold counter" data-target="18">0</p>
@@ -18,3 +18,4 @@
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/stats.js"></script>

--- a/web-tutelkan/src/components/sections/Support.astro
+++ b/web-tutelkan/src/components/sections/Support.astro
@@ -20,3 +20,4 @@ const supportItems = ['Respuesta Rápida','Soporte 24/7','Personal Calificado','
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/support.js"></script>

--- a/web-tutelkan/src/components/sections/Testimonials.astro
+++ b/web-tutelkan/src/components/sections/Testimonials.astro
@@ -19,3 +19,4 @@ const testimonials = [
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/testimonials.js"></script>

--- a/web-tutelkan/src/components/sections/Why.astro
+++ b/web-tutelkan/src/components/sections/Why.astro
@@ -21,3 +21,4 @@
     </div>
   </div>
 </section>
+<script type="module" src="/src/scripts/sections/why.js"></script>

--- a/web-tutelkan/src/pages/index.astro
+++ b/web-tutelkan/src/pages/index.astro
@@ -27,5 +27,4 @@ import '../styles/home.css';
   <Faq />
   <Contact />
   <Map />
-  <script src="../scripts/index.js"></script>
 </Layout>

--- a/web-tutelkan/src/scripts/sectionObserver.js
+++ b/web-tutelkan/src/scripts/sectionObserver.js
@@ -1,7 +1,7 @@
-A// Configuración del observador para animaciones de secciones
-const observerOptions = { 
-  threshold: 0.1, 
-  rootMargin: '0px 0px -100px 0px' 
+// Configuración del observador para animaciones de secciones
+const observerOptions = {
+  threshold: 0.1,
+  rootMargin: '0px 0px -100px 0px'
 };
 
 // Crear el observador de intersección
@@ -10,32 +10,35 @@ const observer = new IntersectionObserver(entries => {
     if (entry.isIntersecting) {
       entry.target.classList.add('section-visible');
       entry.target.classList.remove('section-hidden');
-      
+
       // Iniciar animaciones de elementos
       const animatedElements = entry.target.querySelectorAll('[class*="animate-"]');
       animatedElements.forEach(el => {
         el.style.animationPlayState = 'running';
       });
-      
+
       // Iniciar contadores si existen
       if (entry.target.querySelector('.counter')) {
-        startCounters();
+        startCounters(entry.target);
       }
+
+      // Dejar de observar la sección una vez animada
+      observer.unobserve(entry.target);
     }
   });
 }, observerOptions);
 
-// Función para iniciar los contadores animados
-function startCounters() {
-  const counters = document.querySelectorAll('.counter');
+// Función para iniciar los contadores animados dentro de una sección
+function startCounters(section) {
+  const counters = section.querySelectorAll('.counter');
   counters.forEach(counter => {
     if (counter.dataset.animated) return;
-    
+
     const target = parseInt(counter.dataset.target || '0');
     const duration = 2000;
     const increment = target / (duration / 16);
     let current = 0;
-    
+
     const updateCounter = () => {
       current += increment;
       if (current < target) {
@@ -45,39 +48,33 @@ function startCounters() {
         counter.textContent = target.toLocaleString();
       }
     };
-    
+
     counter.dataset.animated = 'true';
     updateCounter();
   });
 }
 
-// Inicializar cuando el DOM esté listo
-function initializeAnimations() {
-  // Observar todas las secciones con animación
-  document.querySelectorAll('.section-animate').forEach(section => {
-    section.classList.add('section-hidden');
-    observer.observe(section);
-  });
-  
-  // Pausar todas las animaciones inicialmente
-  document.querySelectorAll('[class*="animate-"]').forEach(el => {
+// Inicializar animaciones para una sección
+export function initSection(selector) {
+  const section = document.querySelector(selector);
+  if (!section) return;
+
+  section.classList.add('section-hidden');
+  observer.observe(section);
+
+  // Pausar animaciones inicialmente
+  section.querySelectorAll('[class*="animate-"]').forEach(el => {
     el.style.animationPlayState = 'paused';
   });
-  
-  // Iniciar animaciones del hero inmediatamente
-  const heroElements = document.querySelectorAll('#home [class*="animate-"]');
-  heroElements.forEach(el => {
+}
+
+// Iniciar animaciones del hero inmediatamente
+export function initHero(selector) {
+  const hero = document.querySelector(selector);
+  if (!hero) return;
+
+  hero.querySelectorAll('[class*="animate-"]').forEach(el => {
     el.style.animationPlayState = 'running';
   });
 }
 
-// Ejecutar cuando el DOM esté completamente cargado
-document.addEventListener('DOMContentLoaded', initializeAnimations);
-
-// Backup para cuando la ventana esté completamente cargada
-window.addEventListener('load', () => {
-  const heroElements = document.querySelectorAll('#home [class*="animate-"]');
-  heroElements.forEach(el => {
-    el.style.animationPlayState = 'running';
-  });
-});

--- a/web-tutelkan/src/scripts/sections/about.js
+++ b/web-tutelkan/src/scripts/sections/about.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#about');
+});

--- a/web-tutelkan/src/scripts/sections/clients.js
+++ b/web-tutelkan/src/scripts/sections/clients.js
@@ -1,0 +1,55 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', function () {
+  initSection('#clients');
+
+  // Array completo de logos
+  const logos = [
+    { src: '/images/clients-logos/1-CMPC.webp', alt: 'CMPC' },
+    { src: '/images/clients-logos/2-Arauco.webp', alt: 'Arauco' },
+    { src: '/images/clients-logos/3-PF-Alimentos.webp', alt: 'PF Alimentos' },
+    { src: '/images/clients-logos/3-white.webp', alt: 'White' },
+    { src: '/images/clients-logos/4-Unifrutti.webp', alt: 'Unifrutti' },
+    { src: '/images/clients-logos/5-LFE.webp', alt: 'LFE' },
+    { src: '/images/clients-logos/6-UTalca.webp', alt: 'Utalca' },
+    { src: '/images/clients-logos/7-Socoepa.webp', alt: 'Socoepa' },
+    { src: '/images/clients-logos/8-Oriencoop.webp', alt: 'Oriencoop' },
+    { src: '/images/clients-logos/9-Puertos-de-Talcahuano.webp', alt: 'Puertos de Talcahuano' },
+    { src: '/images/clients-logos/10-Danich.webp', alt: 'Danich' },
+    { src: '/images/clients-logos/11-Nebiolo.webp', alt: 'Nebiolo' },
+    { src: '/images/clients-logos/12-Servimak.webp', alt: 'Servimak' },
+    { src: '/images/clients-logos/13-Forestal-Río-Claro.webp', alt: 'Friosur Klaro' },
+    { src: '/images/clients-logos/14-Promaule.webp', alt: 'Promaule' },
+    { src: '/images/clients-logos/15-double-ju.webp', alt: 'Double Ju' },
+    { src: '/images/clients-logos/16-subus.webp', alt: 'Subus' },
+    { src: '/images/clients-logos/17-flowersindesign.webp', alt: 'Flowers in Design' },
+    { src: '/images/clients-logos/18-pasche.webp', alt: 'Pasche' },
+    { src: '/images/clients-logos/19-logo-gottingen.webp', alt: 'Gottingen' }
+  ];
+
+  const track = document.getElementById('carousel-track');
+  let currentIndex = 0;
+  const visibleLogos = 6;
+
+  function updateCarousel() {
+    track.innerHTML = '';
+
+    for (let i = 0; i < visibleLogos; i++) {
+      const logoIndex = (currentIndex + i) % logos.length;
+      const logoData = logos[logoIndex];
+
+      const img = document.createElement('img');
+      img.src = logoData.src;
+      img.alt = logoData.alt;
+      img.className = `h-24 md:h-28 w-auto flex-shrink-0 opacity-70 hover:opacity-100 hover:scale-105 transition-all duration-300 cursor-pointer animate-fade-scale animate-delay-${i + 1}`;
+
+      track.appendChild(img);
+    }
+
+    currentIndex = (currentIndex + 1) % logos.length;
+  }
+
+  // Inicializar el carrusel
+  updateCarousel();
+  setInterval(updateCarousel, 3000);
+});

--- a/web-tutelkan/src/scripts/sections/contact.js
+++ b/web-tutelkan/src/scripts/sections/contact.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#contact');
+});

--- a/web-tutelkan/src/scripts/sections/faq.js
+++ b/web-tutelkan/src/scripts/sections/faq.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#faq');
+});

--- a/web-tutelkan/src/scripts/sections/hero.js
+++ b/web-tutelkan/src/scripts/sections/hero.js
@@ -1,0 +1,5 @@
+import { initHero } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initHero('#home');
+});

--- a/web-tutelkan/src/scripts/sections/map.js
+++ b/web-tutelkan/src/scripts/sections/map.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#map');
+});

--- a/web-tutelkan/src/scripts/sections/portfolio.js
+++ b/web-tutelkan/src/scripts/sections/portfolio.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#portfolio');
+});

--- a/web-tutelkan/src/scripts/sections/services.js
+++ b/web-tutelkan/src/scripts/sections/services.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#services');
+});

--- a/web-tutelkan/src/scripts/sections/stats.js
+++ b/web-tutelkan/src/scripts/sections/stats.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#stats');
+});

--- a/web-tutelkan/src/scripts/sections/support.js
+++ b/web-tutelkan/src/scripts/sections/support.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#support');
+});

--- a/web-tutelkan/src/scripts/sections/testimonials.js
+++ b/web-tutelkan/src/scripts/sections/testimonials.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#testimonials');
+});

--- a/web-tutelkan/src/scripts/sections/why.js
+++ b/web-tutelkan/src/scripts/sections/why.js
@@ -1,0 +1,5 @@
+import { initSection } from '../sectionObserver.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initSection('#why');
+});


### PR DESCRIPTION
## Summary
- centralize intersection-based animations in `sectionObserver.js`
- move each section's JavaScript into `src/scripts/sections`
- convert Clients carousel into standalone module and add IDs where needed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68925e68f3c4832c95521a250f25d1c6