### PR TITLE
Refina fondo y animaciones de scroll

### DIFF
--- a/web-tutelkan/src/layouts/Layout.astro
+++ b/web-tutelkan/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const { title = 'Tutelkan' } = Astro.props;
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <body class="bg-white text-gray-900">
     <Navbar />
     <main>
       <slot />

--- a/web-tutelkan/src/scripts/sectionObserver.js
+++ b/web-tutelkan/src/scripts/sectionObserver.js
@@ -1,7 +1,8 @@
 // Configuración del observador para animaciones de secciones
 const observerOptions = {
   threshold: 0.1,
-  rootMargin: '0px 0px -100px 0px'
+  // Trigger animations slightly before the section enters the viewport
+  rootMargin: '0px 0px -50px 0px'
 };
 
 // Crear el observador de intersección

--- a/web-tutelkan/src/styles/global.css
+++ b/web-tutelkan/src/styles/global.css
@@ -1,9 +1,11 @@
 @import "tailwindcss";
 
+
+/* General fade-in effect for sections */
 .fade-section {
   opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.7s ease, transform 0.7s ease;
+  transform: translateY(10px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
 }
 
 .fade-section.show {


### PR DESCRIPTION
## Summary
- Ajusta el `<body>` para que la onepage mantenga un fondo claro y uniforme.
- Suaviza las animaciones de aparición reduciendo la traducción vertical y la duración del fade.
- Activa antes las animaciones de sección para un desplazamiento más fluido.

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892624a5b1c832c88b6a2fbd5db4ed1