### PR TITLE
fix: update dark mode text colors

### DIFF
--- a/web-tutelkan/src/styles/global.css
+++ b/web-tutelkan/src/styles/global.css
@@ -12,3 +12,10 @@
   opacity: 1;
   transform: translateY(0);
 }
+html.dark .text-gray-500,
+html.dark .text-gray-600,
+html.dark .text-gray-700,
+html.dark .text-gray-800,
+html.dark .text-gray-900 {
+  color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- keep red text consistent while dark mode sets gray tones to white

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894b022d320832c8a819a8c5177ac51