### PR TITLE
Fix theme toggle in mobile menu

### DIFF
--- a/web-tutelkan/src/components/ThemeToggle.astro
+++ b/web-tutelkan/src/components/ThemeToggle.astro
@@ -1,13 +1,12 @@
 ---
 ---
-<button 
-  id="theme-toggle" 
-  class="w-10 h-10 sm:w-12 sm:h-12 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-all duration-200 dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500 relative overflow-hidden"
+<button
+  class="theme-toggle w-10 h-10 sm:w-12 sm:h-12 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-all duration-200 dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500 relative overflow-hidden"
   aria-label="Cambiar tema"
 >
   <div class="relative w-5 h-5 sm:w-6 sm:h-6">
-    <i id="theme-toggle-light" class="bi bi-sun-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 transform rotate-0 scale-100 opacity-100"></i>
-    <i id="theme-toggle-dark" class="bi bi-moon-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 transform -rotate-90 scale-0 opacity-0"></i>
+    <i class="theme-toggle-light bi bi-sun-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 transform rotate-0 scale-100 opacity-100"></i>
+    <i class="theme-toggle-dark bi bi-moon-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 transform -rotate-90 scale-0 opacity-0"></i>
   </div>
 </button>
 

--- a/web-tutelkan/src/scripts/toggle.js
+++ b/web-tutelkan/src/scripts/toggle.js
@@ -1,31 +1,42 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const themeToggle = document.getElementById('theme-toggle');
-  const lightIcon = document.getElementById('theme-toggle-light');
-  const darkIcon = document.getElementById('theme-toggle-dark');
   const html = document.documentElement;
-  const getTheme = () => localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  const toggles = document.querySelectorAll('.theme-toggle');
+  const getTheme = () =>
+    localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
   const applyTheme = (theme) => {
     if (theme === 'dark') {
       html.classList.add('dark');
-      lightIcon.style.transform = 'rotate(90deg) scale(0)';
-      lightIcon.style.opacity = '0';
-      darkIcon.style.transform = 'rotate(0deg) scale(1)';
-      darkIcon.style.opacity = '1';
     } else {
       html.classList.remove('dark');
-      lightIcon.style.transform = 'rotate(0deg) scale(1)';
-      lightIcon.style.opacity = '1';
-      darkIcon.style.transform = 'rotate(-90deg) scale(0)';
-      darkIcon.style.opacity = '0';
     }
+
+    toggles.forEach((toggle) => {
+      const lightIcon = toggle.querySelector('.theme-toggle-light');
+      const darkIcon = toggle.querySelector('.theme-toggle-dark');
+
+      if (theme === 'dark') {
+        lightIcon.style.transform = 'rotate(90deg) scale(0)';
+        lightIcon.style.opacity = '0';
+        darkIcon.style.transform = 'rotate(0deg) scale(1)';
+        darkIcon.style.opacity = '1';
+      } else {
+        lightIcon.style.transform = 'rotate(0deg) scale(1)';
+        lightIcon.style.opacity = '1';
+        darkIcon.style.transform = 'rotate(-90deg) scale(0)';
+        darkIcon.style.opacity = '0';
+      }
+    });
+
     localStorage.setItem('theme', theme);
   };
+
   applyTheme(getTheme());
-  if (themeToggle) {
-    themeToggle.addEventListener('click', () => {
-      const currentTheme = getTheme();
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+  toggles.forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      const newTheme = getTheme() === 'dark' ? 'light' : 'dark';
       applyTheme(newTheme);
     });
-  }
+  });
 });

--- a/web-tutelkan/src/styles/global.css
+++ b/web-tutelkan/src/styles/global.css
@@ -39,25 +39,25 @@ html.dark .bg-gray-100 {
   background-color: #121212;
 }
 
-#theme-toggle {
+.theme-toggle {
   aspect-ratio: 1;
   min-width: 2.5rem;
 }
 
 @media (min-width: 640px) {
-  #theme-toggle {
+  .theme-toggle {
     min-width: 3rem;
   }
 }
 
-#theme-toggle i {
+.theme-toggle i {
   will-change: transform, opacity;
 }
 
-#theme-toggle:hover {
+.theme-toggle:hover {
   transform: scale(1.05);
 }
 
-#theme-toggle:active {
+.theme-toggle:active {
   transform: scale(0.95);
 }


### PR DESCRIPTION
## Summary
- support multiple theme toggles across the site
- style theme toggle with a reusable class

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f5d2a4b8832c82a5912637ec63fb