### PR TITLE
feat: make navbar background white

### DIFF
--- a/web-tutelkan/src/components/Navbar.astro
+++ b/web-tutelkan/src/components/Navbar.astro
@@ -9,7 +9,7 @@ const links = [
 ];
 ---
 
-<nav id="navbar" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300 ease-in-out bg-white dark:bg-gray-800">
+<nav id="navbar" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300 ease-in-out bg-white">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-20">
       <a href="/" class="flex items-center space-x-2 flex-shrink-0">
@@ -19,7 +19,7 @@ const links = [
         <ul class="flex items-center space-x-6 xl:space-x-10">
           {links.map((link, index) => (
             <li>
-              <a href={link.href} class={`nav-link text-base xl:text-lg font-medium transition-colors duration-200 hover:text-[#cf3339] whitespace-nowrap ${index === 0 ? 'text-[#cf3339]' : 'text-black dark:text-white'}`}>
+              <a href={link.href} class={`nav-link text-base xl:text-lg font-medium transition-colors duration-200 hover:text-[#cf3339] whitespace-nowrap ${index === 0 ? 'text-[#cf3339]' : 'text-black'}`}>
                 {link.label}
               </a>
             </li>
@@ -32,7 +32,7 @@ const links = [
         </a>
         <ThemeToggle />
       </div>
-      <button id="mobile-menu-button" type="button" class="lg:hidden text-black dark:text-white hover:text-[#cf3339] focus:outline-none focus:text-[#cf3339] transition-colors duration-200" aria-controls="mobile-menu" aria-expanded="false">
+      <button id="mobile-menu-button" type="button" class="lg:hidden text-black hover:text-[#cf3339] focus:outline-none focus:text-[#cf3339] transition-colors duration-200" aria-controls="mobile-menu" aria-expanded="false">
         <span class="sr-only">Abrir menú principal</span>
         <svg class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
@@ -41,9 +41,9 @@ const links = [
     </div>
   </div>
   <div id="mobile-menu" class="lg:hidden max-h-0 opacity-0 overflow-hidden transition-all duration-300 ease-in-out origin-top pointer-events-none">
-    <div class="px-4 pt-2 pb-3 space-y-1 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg">
+    <div class="px-4 pt-2 pb-3 space-y-1 bg-white border-t border-gray-200 dark:border-gray-700 shadow-lg">
       {links.map((link, index) => (
-        <a href={link.href} class={`nav-link block px-3 py-2 text-base font-medium transition-colors duration-200 hover:text-[#cf3339] hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md ${index === 0 ? 'text-[#cf3339]' : 'text-black dark:text-white'}`}>
+        <a href={link.href} class={`nav-link block px-3 py-2 text-base font-medium transition-colors duration-200 hover:text-[#cf3339] hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md ${index === 0 ? 'text-[#cf3339]' : 'text-black'}`}>
           {link.label}
         </a>
       ))}
@@ -51,7 +51,7 @@ const links = [
         Conversemos
       </a>
       <div class="flex items-center justify-between px-3 py-2 border-t border-gray-200 dark:border-gray-700 mt-4 pt-4">
-        <span class="text-base font-medium text-black dark:text-white">Tema</span>
+        <span class="text-base font-medium text-black">Tema</span>
         <ThemeToggle />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make the navbar use a white background on all themes
- adjust link and toggle text colors for readability

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899fb4d76d4832c8e84d6f77f71f441