### PR TITLE
Ensure theme toggle uses consistent colors

### DIFF
--- a/web-tutelkan/src/components/ThemeToggle.astro
+++ b/web-tutelkan/src/components/ThemeToggle.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <button
-  class="theme-toggle w-10 h-10 sm:w-12 sm:h-12 flex items-center text-gray-800 justify-center rounded-full bg-white hover:bg-gray-100 transition-all duration-200 dark:bg-gray-800 dark:hover:bg-gray-700  relative overflow-hidden"
+  class="theme-toggle w-10 h-10 sm:w-12 sm:h-12 flex items-center justify-center rounded-full transition-all duration-200 relative overflow-hidden"
   aria-label="Cambiar tema"
 >
   <div class="relative w-5 h-5 sm:w-6 sm:h-6">

--- a/web-tutelkan/src/styles/global.css
+++ b/web-tutelkan/src/styles/global.css
@@ -32,22 +32,17 @@ html.dark .text-gray-900 {
 }
 
 .theme-toggle{
-  background-color: #3d3d3d;
+  background-color: #ffffff;
   border-radius: 50%;
   padding: 0.375rem 0.75rem;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #212529;
+  color: #3d3d3d;
   transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 html.dark .theme-toggle {
-  background-color: #f8f9fa !important;
-  border-radius: 50%;
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #262726;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  background-color: #ffffff !important;
+  color: #3d3d3d;
 }
 
 html.dark .nav-link {
@@ -82,6 +77,7 @@ html.dark .bg-gray-100 {
 
 .theme-toggle i {
   will-change: transform, opacity;
+  color: #3d3d3d;
 }
 
 .theme-toggle:hover {


### PR DESCRIPTION
## Summary
- Keep theme toggle background white and icons dark gray in both modes
- Remove dark mode classes and centralize styles in CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a08ea9fdc832c89d52c6171ab2929