### PR TITLE
Fix dark mode icon not appearing

### DIFF
--- a/web-tutelkan/src/components/ThemeToggle.astro
+++ b/web-tutelkan/src/components/ThemeToggle.astro
@@ -5,8 +5,8 @@
   aria-label="Cambiar tema"
 >
   <div class="relative w-5 h-5 sm:w-6 sm:h-6">
-    <i class="theme-toggle-light bi bi-sun-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 transform rotate-0 scale-100 opacity-100"></i>
-    <i class="theme-toggle-dark bi bi-moon-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 transform -rotate-90 scale-0 opacity-100 " ></i>
+    <i class="theme-toggle-light bi bi-sun-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300"></i>
+    <i class="theme-toggle-dark bi bi-moon-fill absolute inset-0 flex items-center justify-center text-base sm:text-lg transition-all duration-300 hidden"></i>
   </div>
 </button>
 

--- a/web-tutelkan/src/scripts/toggle.js
+++ b/web-tutelkan/src/scripts/toggle.js
@@ -5,26 +5,20 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
   const applyTheme = (theme) => {
-    if (theme === 'dark') {
-      html.classList.add('dark');
-    } else {
-      html.classList.remove('dark');
-    }
+    html.classList.toggle('dark', theme === 'dark');
 
     toggles.forEach((toggle) => {
       const lightIcon = toggle.querySelector('.theme-toggle-light');
       const darkIcon = toggle.querySelector('.theme-toggle-dark');
 
+      if (!lightIcon || !darkIcon) return;
+
       if (theme === 'dark') {
-        lightIcon.style.transform = 'rotate(90deg) scale(0)';
-        lightIcon.style.opacity = '0';
-        darkIcon.style.transform = 'rotate(0deg) scale(1)';
-        darkIcon.style.opacity = '1';
+        lightIcon.classList.add('hidden');
+        darkIcon.classList.remove('hidden');
       } else {
-        lightIcon.style.transform = 'rotate(0deg) scale(1)';
-        lightIcon.style.opacity = '1';
-        darkIcon.style.transform = 'rotate(-90deg) scale(0)';
-        darkIcon.style.opacity = '0';
+        lightIcon.classList.remove('hidden');
+        darkIcon.classList.add('hidden');
       }
     });
 
@@ -35,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   toggles.forEach((toggle) => {
     toggle.addEventListener('click', () => {
-      const newTheme = getTheme() === 'dark' ? 'light' : 'dark';
+      const newTheme = html.classList.contains('dark') ? 'light' : 'dark';
       applyTheme(newTheme);
     });
   });


### PR DESCRIPTION
## Summary
- Ensure dark mode button shows the moon icon when activated by hiding and showing icons with CSS classes
- Simplify ThemeToggle component markup for clearer icon handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a0ad94860832cb030642f613da8bb